### PR TITLE
eslint-plugin-prettierの推奨設定に変更して、prittierの設定を切り出しました

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,21 +6,13 @@
   },
   "extends": [
     "eslint:recommended",
-    "prettier"
+    "plugin:prettier/recommended"
   ],
-  "plugins": ["prettier"],
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": 8
   },
   "rules": {
-    "prettier/prettier": [
-      "error",
-      {
-        "singleQuote": true,
-        "trailingComma": "es5",
-        "tabWidth": 4
-      }
-    ],
+    "no-console": 0
   }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 4
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 exports.handler = async (event, context, callback) => {
+    console.log('Event', event);
+    console.log('context', context);
     if (event.result === 'failure') {
         return callback(new Error('error end'));
     }


### PR DESCRIPTION
## PR内容
以下の推奨設定にしたがってeslintrcの設定を見直しました。
あわせて、prettierの設定も外出ししました

設定の持ち方を変えただけなので、動作に変更はありません
![image](https://user-images.githubusercontent.com/10177370/40574459-11d090d0-610d-11e8-91bc-78664f427591.png)

https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
cf. [アメブロに ESLint + Prettier で自動コード整形を導入した話
](https://developers.cyberagent.co.jp/blog/archives/15068/)

## 変更点
* eslint-plugin-prettierの推奨設定に合わせてeslintrcを変更
* eslintrcからprettierの設定を切り出し
* eslintのruleとしてno-consoleを追加