### PR TITLE
junit reportのCI設定を追加しました

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,13 @@ jobs:
       # run tests!
       - run:
           name: start eslint
-          command: yarn lint
+          command: yarn lint --format junit -o reports/junit/js-lint-results.xml
       - run:
           name: start test
-          command: yarn test
+          command: yarn test --ci --testResultsProcessor="jest-junit"
+          environment:
+            JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Enable to focus on cording with node-lambda",
   "main": "index.js",
-  "repository": "git@github.com:mesh1neko/node-lambda-starter-kit.git",
+  "repository": "git@github.com:mesh1nek0x0/node-lambda-starter-kit.git",
   "author": "iida-ryota <mesh1nek0x0@gmail.com>",
   "license": "MIT",
   "scripts": {
@@ -16,6 +16,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "jest": "^22.4.4",
+    "jest-junit": "^4.0.0",
     "node-lambda": "^0.11.7",
     "prettier": "^1.12.1",
     "sinon": "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,6 +2172,14 @@ jest-jasmine2@^22.4.4:
     jest-util "^22.4.1"
     source-map-support "^0.5.0"
 
+jest-junit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-4.0.0.tgz#6af04d43940d7e81dc7d37ec1b80c97551d91e80"
+  dependencies:
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^22.4.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
@@ -4066,6 +4074,10 @@ xml2js@0.4.17:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "^4.1.0"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
 
 xmlbuilder@^4.1.0:
   version "4.2.1"


### PR DESCRIPTION
## PR内容
CIでのテスト時、ESLintとJestをJunit形式でレポートファイルを生成する設定を追加しました
cf. #10 

テスト結果が以下のようになります。
![image](https://user-images.githubusercontent.com/10177370/40592237-c8ae9f4a-6257-11e8-8980-61d7a2f6cbea.png)

## 変更点
* jestのjunit用レポーターの追加
* CIの設定で、ESLintとJestのレポートを設定
* CI時、テスト結果をstore、artifactsの両方に配置

## その他変更点
* ユーザ名変更に伴うレポジトリ名を変更(package.json)